### PR TITLE
Close navigation drawer by default and other minor improvements

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -65,7 +65,7 @@ export default {
   data: () => ({
     mini: false,
     appName: constants.systemConstants.appName,
-    drawer: true
+    drawer: false
   }),
   methods: {
     changeNavbar() {

--- a/store/authentication.js
+++ b/store/authentication.js
@@ -23,9 +23,6 @@ const getters = {
 
         return !!state.user || !!token;
     },
-    getUserRole: state => {
-        return state.user === "r730819" ? "admin" : "manager";
-    },
     getUsernameIntial: state => {
         if (state.user) {
             return state.user.charAt(0).toUpperCase();


### PR DESCRIPTION
Minor changed, made it so the navigation drawer stays closed until the user decides to open it. Should remove an unnecessary click when logging into Togglr