### PR TITLE
Feature/sorting

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -14,6 +14,9 @@ var urlConstants = Object.freeze({
     addApplicationPOST: `${baseURL}appEntities`,
     retrieveAppDetailsGET: `${baseURL}appEntities/`,
     deleteApplication: `${baseURL}appEntities/`,
+    retrieveApplicationFeatures: `${baseURL}featureEntities/search/findByAppId?appId=`,
+    retrieveApplicationKeys: `${baseURL}keysEntities/search/findByAppId?appId=`,
+    retrieveConfigsByApplicationAndFeature: `${baseURL}configsEntities/search/findByAppIdAndFeatureId?appId=`, // include &featureId={featureIdInt}
     updateFeature: `${baseURL}featureEntities/`,
     updateKey: `${baseURL}keysEntities/`,
     adminEntity: `${baseURL}adminsEntities/`,

--- a/components/misc/EditFeatureDialog.vue
+++ b/components/misc/EditFeatureDialog.vue
@@ -209,7 +209,7 @@ export default {
                 });
               }
             }
-        } 
+        }
         this.configsLoaded = true;
         this.updateRuleSummary();
       }

--- a/components/misc/EditFeatureDialog.vue
+++ b/components/misc/EditFeatureDialog.vue
@@ -27,7 +27,7 @@
 
       <v-divider></v-divider>
 
-        <v-card v-for="key in applicationKeys.payload" :key="key.keyName">
+      <v-card v-for="key in applicationKeys.payload" :key="key.keyName">
         <v-container fluid>
           <v-layout row wrap>
             <v-flex xs12>{{key.keyName}}</v-flex>
@@ -97,7 +97,7 @@ export default {
     },
     deleteConfigObject() {
       return this.$store.state.applications.deleteConfig;
-        },
+    },
     applicationFeatureConfigs() {
       return this.$store.state.applications.applicationFeatureConfigs;
     },
@@ -196,20 +196,19 @@ export default {
     featureConfigs: {
       handler(newConfigs, oldConfigs) {
           if (this.configsLoaded && this.currentKey !== "") {
-          //Adding an admin
-          if (newConfigs.length > oldConfigs.length) {
-            var configToAdd = newConfigs.filter(
-              config => !oldConfigs.includes(config)
-            );
-            if (configToAdd.length > 0) {
-              this.addConfig({
-                appId: this.editFeatureDialog.appDetails.id,
-                featureId: this.editFeatureDialog.feature.id,
-                keyName: this.currentKey,
-                configValue: configToAdd[0]
-              });
+            if (newConfigs.length > oldConfigs.length) {
+              var configToAdd = newConfigs.filter(
+                config => !oldConfigs.includes(config)
+              );
+              if (configToAdd.length > 0) {
+                this.addConfig({
+                  appId: this.editFeatureDialog.appDetails.id,
+                  featureId: this.editFeatureDialog.feature.id,
+                  keyName: this.currentKey,
+                  configValue: configToAdd[0]
+                });
+              }
             }
-          }
         } 
         this.configsLoaded = true;
         this.updateRuleSummary();

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -214,8 +214,8 @@ export default {
     } else {
       this.webhookUrl = this.storedApp.webhookUrl;
       this.retrieveApplicationDetails(this.storedApp.id);
-      this.retrieveApplicationFeatures(this.storedApp.id);
-      this.retrieveApplicationKeys(this.storedApp.id);
+      this.retrieveApplicationFeatures({appId: this.storedApp.id, sortBy: 'descr', sortOrder: 'asc'});
+      this.retrieveApplicationKeys({appId: this.storedApp.id, sortBy: 'keyName', sortOrder: 'asc'});
     }
   },
   data: () => ({

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -284,7 +284,7 @@ export default {
   methods: {
     async openEditFeatureDialog(appAndFeatureObjects) {
       await this.showEditFeatureDialog({ app: appAndFeatureObjects.app, feature: appAndFeatureObjects.feature });
-      await this.retrieveConfigsByApplicationAndFeature({appId: appAndFeatureObjects.app.id, featureId: appAndFeatureObjects.feature.id})
+      await this.retrieveConfigsByApplicationAndFeature({appId: appAndFeatureObjects.app.id, featureId: appAndFeatureObjects.feature.id});
     },
     changeSort(column) {
       if (this.pagination.sortBy === column) {
@@ -302,7 +302,7 @@ export default {
       this.updateApplication(feature);
     },
     addFeatureEvent() {
-      this.$validator.validate("featureName", this.featureName).then(async res => {
+      this.$validator.validate("featureName", this.featureName).then(res => {
         if (res) {
           this.addFeature({
             descr: this.featureName,
@@ -323,9 +323,9 @@ export default {
       }
     },
     addKeyEvent() {
-      this.$validator.validate("keyName", this.keyName).then(async res => {
+      this.$validator.validate("keyName", this.keyName).then(res => {
         if (res) {
-          await this.addKey({
+          this.addKey({
             keyName: this.keyName,
             appId: this.appDetails.payload.id
           });

--- a/store/applications.js
+++ b/store/applications.js
@@ -203,11 +203,13 @@ const actions = {
     async retrieveApplicationFeatures({
         commit,
         dispatch
-    }, appId, sortBy="descr", sortOrder="asc") {
+    }, payload) {
         commit("retrieveApplicationFeatures")
         try {
+            if (!payload.sortBy) payload.sortBy = 'descr';
+            if (!payload.sortOrder) payload.sortOrder = 'asc';
             const features = await this.$axios.$get(
-                `${constants.urlConstants.retrieveApplicationFeatures}${appId}&sort=${sortBy},${sortOrder}`
+                `${constants.urlConstants.retrieveApplicationFeatures}${payload.appId}&sort=${payload.sortBy},${payload.sortOrder}`
             );
             if (features._embedded && features._embedded.featureEntities) {
                 commit("retrieveApplicationFeaturesSuccess", features._embedded.featureEntities);
@@ -245,11 +247,13 @@ const actions = {
     async retrieveApplicationKeys({
         commit,
         dispatch
-    }, appId, sortBy="keyName", sortOrder="asc") {
+    }, payload) {
         commit("retrieveApplicationKeys")
         try {
+            if (!payload.sortBy) payload.sortBy = 'keyName';
+            if (!payload.sortOrder) payload.sortOrder = 'asc';
             const keys = await this.$axios.$get(
-                `${constants.urlConstants.retrieveApplicationKeys}${appId}&sort=${sortBy},${sortOrder}`
+                `${constants.urlConstants.retrieveApplicationKeys}${payload.appId}&sort=${payload.sortBy},${payload.sortOrder}`
             );
             if (keys._embedded && keys._embedded.keysEntities) {
                 commit("retrieveApplicationKeysSuccess", keys._embedded.keysEntities);

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -12,6 +12,7 @@ const state = () => ({
     editFeatureDialog: {
         showing: false,
         feature: null,
+        configs: [],
         appDetails: null
     },
     confirmCancelDialog: {
@@ -42,6 +43,11 @@ const actions = {
         commit
     }) {
         commit("hideSnackbar");
+    },
+    setEditFeatureDialogConfigs({
+        commit
+    }, configs) {
+        commit("setEditFeatureDialogConfigs", configs);
     },
     showEditFeatureDialog({
         commit
@@ -112,21 +118,27 @@ const mutations = {
         state.editFeatureDialog.feature = appConfig.feature;
         state.editFeatureDialog.appDetails = appConfig.app;
         state.editFeatureDialog.configsById = appConfig.feature.configsById;
+        state.editFeatureDialog.configs = []
     },
     hideEditFeatureDialog(state) {
         state.editFeatureDialog.showing = false;
         state.editFeatureDialog.feature = null;
     },
-    editFeatureConfigDeleted(state, configId) {
-        var index = state.editFeatureDialog.feature.configsById.findIndex(
-            config => config.appId === configId.appId &&
-            config.keyName === configId.keyName &&
-            config.configValue === configId.configValue &&
-            config.featureId === configId.featureId
+    setEditFeatureDialogConfigs(state, configs) {
+        state.editFeatureDialog.configs = configs;
+    },
+    editFeatureConfigDeleted(state, deletedConfig) {
+        // finds where (index position) in the editFeatureDialog.configs the recently deleted config is
+        let index = state.editFeatureDialog.configs.findIndex(
+            config => config.appId === deletedConfig.appId &&
+            config.keyName === deletedConfig.keyName &&
+            config.configValue === deletedConfig.configValue &&
+            config.featureId === deletedConfig.featureId
         );
 
-        if (index > -1) {
-            state.editFeatureDialog.feature.configsById.splice(index, 1);
+        // removes it from that array that is populating the UI
+        if (index > -1 ) {
+            state.editFeatureDialog.configs.splice(index, 1);
         }
     },
     editFeatureCorpDeleted(state, corpId) {
@@ -139,7 +151,7 @@ const mutations = {
         }
     },
     editFeatureConfigAdded(state, config) {
-        state.editFeatureDialog.feature.configsById.push(config);
+        state.editFeatureDialog.configs.push(config);
     },
     showConfirmCancelDialog(state, options) {
         state.confirmCancelDialog.showing = true;


### PR DESCRIPTION
This is the UI complement to [this api PR](https://github.com/HEB/togglr-api/pull/18).
Please note it touches the same file applicationDetails.vue, but different lines of code, as [this PR ](https://github.com/HEB/togglr-ui/pull/14)

Requirement was to have the API be able to do sorting first and then the UI can take over. To do this, we switched away from using the data projection returned from togglr-api/{appId}?projection=includeSubObjects for features, keys and configs and now get keys and features back from search endpoints when loading an application’s details. The sorting is done by the Togglr API (part of PR linked at the top) initially and then the UI will do any future sorting by name. Configs are returned to Togglr using a search endpoint with both appId and featureId as the query params.

 [Link to GitHub issue](https://github.com/HEB/togglr/issues/11)

Because we are getting features, keys and configs back separately now from the search endpoints, we added new properties (arrays) in applications.js store module for features/keys/configs with matching actions and mutators. The arrays are used in the components that show those entities to the user. When new entities are created or existing ones deleted, we update those new arrays instead of the old ones that the project would return (same way that it was originally being done). 

Scenarios tested:
Adding new keys to an application
Adding new features to an application
Adding new configs to a feature
Deleting keys
Deleting features
Deleting configs
Sorting by name using the UI tables for keys and features
Making sure the right configs/keys/features showed up for the right app
Toggling features on/off
Negating rules on/off