### PR TITLE
Feature/ssoadmins

### DIFF
--- a/store/authentication.js
+++ b/store/authentication.js
@@ -11,6 +11,7 @@ const state = () => ({
     logoutDialogShowing: false,
     jwt: null,
     user: "",
+    roles: [],
     corpId: 1
 });
 
@@ -22,6 +23,17 @@ const getters = {
         );
 
         return !!state.user || !!token;
+    },
+    isUserSuperAdmin: state => {
+        if (state.roles){
+            let superAdmin = state.roles.filter(
+                role => role.authority.toUpperCase() === 'ROLE_SUPERADMIN'
+            );
+            if (superAdmin.length > 0) {
+                return true;
+            }
+        }
+        return false;
     },
     getUsernameIntial: state => {
         if (state.user) {
@@ -96,6 +108,7 @@ const mutations = {
 
         let decoded = jsonwebtoken.decode(jwt);
         state.user = decoded.details.username;
+        state.roles = decoded.details.authorities
     },
     login(state) {
         state.loginInProgress = true;


### PR DESCRIPTION
This is a support functionality to [the SSO feature](https://github.com/HEB/togglr/issues/1), but does not add SSO. This PR goes along [with one for the API.](https://github.com/HEB/togglr-api/pull/19)

Adding an Admins table to applicationDetails. Anyone logged into Togglr can add admins to their application. The API PR for this returns a ROLE_SUPERADMIN as a user role, so the UI also now knows whether or not the person logged in is a super admin (meaning they can delete admins). 