### PR TITLE
Feature/ssologin

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -1,7 +1,8 @@
 var systemConstants = Object.freeze({
     appName: "Togglr",
     userSettingsCookieName: "togglr-settings-token",
-    authCookieIdentifer: "X-TOGGLR-TOKEN",
+    togglrAuthCookieIdentifer: "X-TOGGLR-TOKEN",
+    oauthCookieIdentifier: "OAUTH-TOKEN",
     featureFlagAppId: 3,
     version: "0.9.0"
 });

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -22,7 +22,7 @@ var urlConstants = Object.freeze({
     configsEntity: `${baseURL}configsEntities/`,
     login: `${baseURL}login`,
     logout: `${baseURL}logout`,
-    ssoLoginUrlGET: `${baseURL}ssologin`
+    oauthLoginUrlGET: `${baseURL}oauth/login`
 });
 
 var disallowedChars = Object.freeze(["_", "/"]);

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -22,7 +22,7 @@ var urlConstants = Object.freeze({
     configsEntity: `${baseURL}configsEntities/`,
     login: `${baseURL}login`,
     logout: `${baseURL}logout`,
-    ssologin: `${baseURL}ssologin`
+    ssoLoginUrlGET: `${baseURL}ssologin`
 });
 
 var disallowedChars = Object.freeze(["_", "/"]);

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -3,6 +3,7 @@ var systemConstants = Object.freeze({
     userSettingsCookieName: "togglr-settings-token",
     togglrAuthCookieIdentifer: "X-TOGGLR-TOKEN",
     oauthCookieIdentifier: "OAUTH-TOKEN",
+    oauthHeader: "Authorization",
     featureFlagAppId: 3,
     version: "0.9.0"
 });

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -19,7 +19,8 @@ var urlConstants = Object.freeze({
     adminEntity: `${baseURL}adminsEntities/`,
     configsEntity: `${baseURL}configsEntities/`,
     login: `${baseURL}login`,
-    logout: `${baseURL}logout`
+    logout: `${baseURL}logout`,
+    ssologin: `${baseURL}ssologin`
 });
 
 var disallowedChars = Object.freeze(["_", "/"]);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -35,7 +35,7 @@ export default function(context) {
         const oauthBearer = Cookie.get(constants.systemConstants.oauthCookieIdentifier);
         
         if (oauthBearer) {
-            context.$axios.defaults.headers.common['Authorization'] = 'Bearer ' + oauthBearer
+            context.$axios.defaults.headers.common[constants.systemConstants.oauthHeader] = 'Bearer ' + oauthBearer
         }
         
         if (jwt) {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -11,12 +11,16 @@ export default function(context) {
 
     if (!context.store.getters["authentication/isUserAuthenticated"]) {
 
-        const jwt = Cookie.get(constants.systemConstants.authCookieIdentifer);
-        const bearer = Cookie.get(constants.systemConstants.ssoCookieIdentifier);
+        const jwt = Cookie.get(constants.systemConstants.togglrAuthCookieIdentifer);
+        const oauthBearer = Cookie.get(constants.systemConstants.oauthCookieIdentifier);
+        
+        if (oauthBearer) {
+            context.$axios.defaults.headers.common['Authorization'] = 'Bearer ' + oauthBearer
+        }
 
         if (jwt) {
             context.$axios.defaults.headers.common[
-                constants.systemConstants.authCookieIdentifer
+                constants.systemConstants.togglrAuthCookieIdentifer
             ] = jwt;
 
             context.store.commit("authentication/saveJWT", jwt);
@@ -26,11 +30,17 @@ export default function(context) {
         }
     } else {
 
-        const jwt = Cookie.get(constants.systemConstants.authCookieIdentifer);
+        const jwt = Cookie.get(constants.systemConstants.togglrAuthCookieIdentifer);
 
+        const oauthBearer = Cookie.get(constants.systemConstants.oauthCookieIdentifier);
+        
+        if (oauthBearer) {
+            context.$axios.defaults.headers.common['Authorization'] = 'Bearer ' + oauthBearer
+        }
+        
         if (jwt) {
             context.$axios.defaults.headers.common[
-                constants.systemConstants.authCookieIdentifer
+                constants.systemConstants.togglrAuthCookieIdentifer
             ] = jwt;
 
             context.store.commit("authentication/saveJWT", jwt);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -12,6 +12,7 @@ export default function(context) {
     if (!context.store.getters["authentication/isUserAuthenticated"]) {
 
         const jwt = Cookie.get(constants.systemConstants.authCookieIdentifer);
+        const bearer = Cookie.get(constants.systemConstants.ssoCookieIdentifier);
 
         if (jwt) {
             context.$axios.defaults.headers.common[

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -15,7 +15,7 @@ export default function(context) {
         const oauthBearer = Cookie.get(constants.systemConstants.oauthCookieIdentifier);
         
         if (oauthBearer) {
-            context.$axios.defaults.headers.common['Authorization'] = 'Bearer ' + oauthBearer
+            context.$axios.defaults.headers.common[constants.systemConstants.oauthHeader] = 'Bearer ' + oauthBearer
         }
 
         if (jwt) {

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -14,7 +14,7 @@
           <v-card flat :color="darkThemeEnabled ? 'darkBackground' : 'lightGrey'" class="mb-4 pa-2">
             <span class="text-xs-left">{{ appDetails.payload.id }}</span>
             <span class="float-right mr-1" @click="copyToClipboard(appDetails.payload.id)">
-              <v-icon class="copy-icon">file_copy</v-icon>
+              <v-icon>file_copy</v-icon>
             </span>
           </v-card>
 
@@ -447,14 +447,4 @@ export default {
 .buffer {
   height: 40px;
 }
-.copy-icon{
--webkit-user-select: none; /* Chrome/Safari */        
--moz-user-select: none; /* Firefox */
--ms-user-select: none; /* IE10+ */
--khtml-user-select: none; /* webkit (konqueror) browsers */
-/* Rules below not implemented in browsers yet */
--o-user-select: none;
-user-select: none;
-}
-
 </style>

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -14,7 +14,7 @@
           <v-card flat :color="darkThemeEnabled ? 'darkBackground' : 'lightGrey'" class="mb-4 pa-2">
             <span class="text-xs-left">{{ appDetails.payload.id }}</span>
             <span class="float-right mr-1" @click="copyToClipboard(appDetails.payload.id)">
-              <v-icon>file_copy</v-icon>
+              <v-icon class="copy-icon">file_copy</v-icon>
             </span>
           </v-card>
 
@@ -447,4 +447,14 @@ export default {
 .buffer {
   height: 40px;
 }
+.copy-icon{
+-webkit-user-select: none; /* Chrome/Safari */        
+-moz-user-select: none; /* Firefox */
+-ms-user-select: none; /* IE10+ */
+-khtml-user-select: none; /* webkit (konqueror) browsers */
+/* Rules below not implemented in browsers yet */
+-o-user-select: none;
+user-select: none;
+}
+
 </style>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -101,11 +101,13 @@ export default {
         }
       });
     },
-githubLogin(){
+async githubLogin(){
 // this.$router.go('www.google.com');
-console.log(this.ssodata.data);
 window.open(this.ssodata.data,"_self");
+// let code = await this.$axios.get(this.ssodata.data);
+// console.log(code);
 },
+
     ...mapActions({
       login: "authentication/login"
     })

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -46,13 +46,14 @@
             :loading="loginInProgress"
           >Log In</v-btn>
         </v-card-actions>
-        <v-card-actions class="card-actions">
+        <v-card-actions class="card-actions" v-if="oauthUrl.trim() !== ''">
           <v-btn
             color="primary"
             class="mb-4 ml-3 mr-3"
             block
             @click="ssoLogin()"
-          >SSO Login</v-btn>
+            :loading="oauthLoginLoading"
+          >Sign In With SSO</v-btn>
         </v-card-actions>
       </v-card>
 
@@ -74,7 +75,8 @@ export default {
     username: "",
     password: "",
     appName: constants.systemConstants.appName,
-    ssoUrl: ""
+    oauthUrl: "",
+    oauthLoginLoading: false
   }),
   computed: {
     loginInProgress() {
@@ -101,7 +103,9 @@ export default {
       });
     },
     ssoLogin(){
-      window.open(this.ssoUrl,"_self");
+      this.errors.clear();
+      this.oauthLoginLoading = true;
+      window.open(this.oauthUrl,"_self");
     },
     ...mapActions({
       login: "authentication/login"
@@ -116,10 +120,10 @@ export default {
   },
 async mounted() {
     try {
-      let sso = await this.$axios.get(`${constants.urlConstants.ssoLoginUrlGET}`);
-      this.ssoUrl = sso.data
+      let url = await this.$axios.get(`${constants.urlConstants.oauthLoginUrlGET}`);
+      this.oauthUrl = url.data
     } catch (err) {
-      console.log(err);
+      console.error(`Had an issue getting oauth login url from the API: ${err.message}`);
     }
   }
 

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -100,7 +100,7 @@ export default {
         }
       });
     },
-    async ssoLogin(){
+    ssoLogin(){
       window.open(this.ssoUrl,"_self");
     },
     ...mapActions({

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -52,7 +52,6 @@
             class="mb-4 ml-3 mr-3"
             block
             @click="ssoLogin()"
-            :loading="loginInProgress"
           >SSO Login</v-btn>
         </v-card-actions>
       </v-card>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -46,8 +46,21 @@
             :loading="loginInProgress"
           >Log In</v-btn>
         </v-card-actions>
+        <v-card-actions class="card-actions">
+          <v-btn
+            color="primary"
+            class="mb-4 ml-3 mr-3"
+            block
+            @click="githubLogin"
+            :loading="loginInProgress"
+          >Login with GitHub</v-btn>
+        </v-card-actions>
       </v-card>
+
     </v-flex>
+
+
+
   </v-layout>
 </template>
 
@@ -61,7 +74,8 @@ export default {
   data: () => ({
     username: "",
     password: "",
-    appName: constants.systemConstants.appName
+    appName: constants.systemConstants.appName,
+    ssodata: ""
   }),
   computed: {
     loginInProgress() {
@@ -74,6 +88,8 @@ export default {
       isUserAuthenticated: "authentication/isUserAuthenticated"
     })
   },
+
+
   methods: {
     attemptLogin() {
       this.$validator.validateAll().then(res => {
@@ -85,6 +101,11 @@ export default {
         }
       });
     },
+githubLogin(){
+// this.$router.go('www.google.com');
+console.log(this.ssodata.data);
+window.open(this.ssodata.data,"_self");
+},
     ...mapActions({
       login: "authentication/login"
     })
@@ -95,8 +116,18 @@ export default {
         this.$router.push("/");
       }
     }
+  },
+async mounted() {
+
+    try {
+      this.ssodata = await this.$axios.get(`${constants.urlConstants.ssologin}`);
+      console.log(ssodata.data);
+    } catch (err) {
+ console.log(err);
+    }
   }
-};
+
+}
 </script>
 
 <style lang="scss" scoped>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -117,7 +117,7 @@ export default {
   },
 async mounted() {
     try {
-      let sso = await this.$axios.get(`${constants.urlConstants.ssologin}`);
+      let sso = await this.$axios.get(`${constants.urlConstants.ssoLoginUrlGET}`);
       this.ssoUrl = sso.data
     } catch (err) {
       console.log(err);

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -51,9 +51,9 @@
             color="primary"
             class="mb-4 ml-3 mr-3"
             block
-            @click="githubLogin"
+            @click="ssoLogin()"
             :loading="loginInProgress"
-          >Login with GitHub</v-btn>
+          >SSO Login</v-btn>
         </v-card-actions>
       </v-card>
 
@@ -75,7 +75,7 @@ export default {
     username: "",
     password: "",
     appName: constants.systemConstants.appName,
-    ssodata: ""
+    ssoUrl: ""
   }),
   computed: {
     loginInProgress() {
@@ -101,13 +101,9 @@ export default {
         }
       });
     },
-async githubLogin(){
-// this.$router.go('www.google.com');
-window.open(this.ssodata.data,"_self");
-// let code = await this.$axios.get(this.ssodata.data);
-// console.log(code);
-},
-
+    async ssoLogin(){
+      window.open(this.ssoUrl,"_self");
+    },
     ...mapActions({
       login: "authentication/login"
     })
@@ -120,12 +116,11 @@ window.open(this.ssodata.data,"_self");
     }
   },
 async mounted() {
-
     try {
-      this.ssodata = await this.$axios.get(`${constants.urlConstants.ssologin}`);
-      console.log(ssodata.data);
+      let sso = await this.$axios.get(`${constants.urlConstants.ssologin}`);
+      this.ssoUrl = sso.data
     } catch (err) {
- console.log(err);
+      console.log(err);
     }
   }
 

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -56,11 +56,7 @@
           >Sign In With SSO</v-btn>
         </v-card-actions>
       </v-card>
-
     </v-flex>
-
-
-
   </v-layout>
 </template>
 

--- a/store/authentication.js
+++ b/store/authentication.js
@@ -75,7 +75,6 @@ const actions = {
             commit("logout");
         } catch (error) {
             commit("logout");
-            console.log("Logout failure:", error.message);
         }
     },
     showLogoutDialog({
@@ -95,7 +94,6 @@ const mutations = {
         state.jwt = jwt;
         let decoded = jsonwebtoken.decode(jwt);
         state.user = decoded.details.username;
-        console.log(state.user);
     },
     login(state) {
         state.loginInProgress = true;

--- a/store/authentication.js
+++ b/store/authentication.js
@@ -18,7 +18,7 @@ const getters = {
     isUserAuthenticated: state => {
 
         const token = Cookie.get(
-            constants.systemConstants.authCookieIdentifer
+            constants.systemConstants.togglrAuthCookieIdentifer
         );
 
         return !!state.user || !!token;
@@ -93,9 +93,9 @@ const actions = {
 const mutations = {
     saveJWT(state, jwt) {
         state.jwt = jwt;
-
         let decoded = jsonwebtoken.decode(jwt);
         state.user = decoded.details.username;
+        console.log(state.user);
     },
     login(state) {
         state.loginInProgress = true;
@@ -122,6 +122,8 @@ const mutations = {
         state.logoutDialogShowing = false;
         state.user = null;
         state.jwt = null;
+        Cookie.remove(constants.systemConstants.togglrAuthCookieIdentifer, {path: '/'});
+        Cookie.remove(constants.systemConstants.oauthCookieIdentifier, {path:'/'})
     },
     showLogoutDialog(state) {
         state.logoutDialogShowing = true;

--- a/store/authentication.js
+++ b/store/authentication.js
@@ -124,7 +124,7 @@ const mutations = {
         state.jwt = null;
         Cookie.remove(constants.systemConstants.togglrAuthCookieIdentifer, {path: '/'});
         Cookie.remove(constants.systemConstants.oauthCookieIdentifier, {path:'/'});
-        delete this.$axios.defaults.headers.common["Authorization"];
+        delete this.$axios.defaults.headers.common[constants.systemConstants.oauthHeader];
         delete this.$axios.defaults.headers.common[constants.systemConstants.togglrAuthCookieIdentifer];
     },
     showLogoutDialog(state) {

--- a/store/authentication.js
+++ b/store/authentication.js
@@ -123,7 +123,9 @@ const mutations = {
         state.user = null;
         state.jwt = null;
         Cookie.remove(constants.systemConstants.togglrAuthCookieIdentifer, {path: '/'});
-        Cookie.remove(constants.systemConstants.oauthCookieIdentifier, {path:'/'})
+        Cookie.remove(constants.systemConstants.oauthCookieIdentifier, {path:'/'});
+        delete this.$axios.defaults.headers.common["Authorization"];
+        delete this.$axios.defaults.headers.common[constants.systemConstants.togglrAuthCookieIdentifer];
     },
     showLogoutDialog(state) {
         state.logoutDialogShowing = true;


### PR DESCRIPTION
This PR makes the following changes to make use of Togglr single sign on. This is all for Github [issue #1](https://github.com/HEB/togglr/issues/1):
    1. New button on the login page. Nuxt makes a GET to get details from API for where to send user for single sign on (JIRA ticket 23)
    2. Setting Authorization header with a Bearer token 
    3. Deleting that header and cookie & the Togglr token header and cookie when logging out