### PR TITLE
Feature/whenwhotoggled

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -65,7 +65,8 @@ module.exports = {
     modules: [
         // Doc: https://github.com/nuxt-community/axios-module#usage
         "@nuxtjs/proxy",
-        "@nuxtjs/axios"
+        "@nuxtjs/axios",
+        "@nuxtjs/moment"
     ],
     /*
      ** Axios module configuration

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@nuxtjs/axios": "5.6.0",
+        "@nuxtjs/moment": "^1.6.1",
         "@nuxtjs/proxy": "1.3.3",
         "js-cookie": "2.2.1",
         "jsonwebtoken": "8.5.1",
@@ -24,9 +25,9 @@
     },
     "devDependencies": {
         "cross-env": "^5.0.1",
+        "node-sass": "^4.14.1",
+        "sass-loader": "^7.0.1",
         "stylus": "^0.54.5",
-        "stylus-loader": "^3.0.1",
-        "node-sass": "^4.9.0",
-        "sass-loader": "^7.0.1"
+        "stylus-loader": "^3.0.1"
     }
 }

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -227,8 +227,8 @@ export default {
     featureHeaders: [
       { text: "Feature", value: "descr", sortable: false },
       { text: "Enabled", value: "enabled", sortable: false },
-      { text: "Last Toggled", value: "lastToggled", sortable: true },
-      { text: "Toggled By", value: "toggledBy", sortable: true },
+      { text: "Last Toggled", value: "lastToggled", sortable: false },
+      { text: "Toggled By", value: "toggledBy", sortable: false },
       { text: "Actions", align: "center", sortable: false }
     ],
     keyHeaders: [
@@ -300,7 +300,6 @@ export default {
     },
     toggleFeature(feature) {
       this.updateApplication(feature);
-      this.retrieveApplicationDetails(this.storedApp.id);
     },
     removeAdmin(item) {
       /* Commented out since Admins disabled

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -59,6 +59,12 @@
                       @change="toggleFeature(props.item)"
                     ></v-switch>
                   </td>
+                  <td>
+                    <span v-if="props.item.lastToggled">{{ $moment(props.item.lastToggled).format('M/D/YYYY h:mm a')}}</span>
+                  </td>
+                  <td>
+                    {{ props.item.toggledBy }}
+                  </td>
                   <td class="text-xs-center">
                     <v-btn
                       slot="activator"
@@ -221,6 +227,8 @@ export default {
     featureHeaders: [
       { text: "Feature", value: "descr", sortable: false },
       { text: "Enabled", value: "enabled", sortable: false },
+      { text: "Last Toggled", value: "lastToggled", sortable: true },
+      { text: "Toggled By", value: "toggledBy", sortable: true },
       { text: "Actions", align: "center", sortable: false }
     ],
     keyHeaders: [
@@ -270,6 +278,9 @@ export default {
     updateWebhookObject() {
       return this.$store.state.applications.updateWebhookObject;
     },
+    user() {
+      return this.$store.state.authentication.user;
+    },
     ...mapGetters({
       getApplicationDetails: "applications/getApplicationDetails"
     })
@@ -289,6 +300,7 @@ export default {
     },
     toggleFeature(feature) {
       this.updateApplication(feature);
+      this.retrieveApplicationDetails(this.storedApp.id);
     },
     removeAdmin(item) {
       /* Commented out since Admins disabled

--- a/pages/applicationDetails.vue
+++ b/pages/applicationDetails.vue
@@ -278,9 +278,6 @@ export default {
     updateWebhookObject() {
       return this.$store.state.applications.updateWebhookObject;
     },
-    user() {
-      return this.$store.state.authentication.user;
-    },
     ...mapGetters({
       getApplicationDetails: "applications/getApplicationDetails"
     })

--- a/store/applications.js
+++ b/store/applications.js
@@ -153,13 +153,17 @@ const actions = {
         }
     },
     async updateFeature({
-        commit
+        commit, rootState
     }, feature) {
         commit("updateFeature");
 
         var unchainedFeature = {
-            active: !feature.active
+            active: !feature.active,
+            lastToggled: Date.now(),
+            toggledBy: rootState.authentication.user
         };
+
+        console.log(unchainedFeature);
 
         try {
             const details = await this.$axios.$patch(

--- a/store/applications.js
+++ b/store/applications.js
@@ -163,15 +163,18 @@ const actions = {
             toggledBy: rootState.authentication.user
         };
 
-        console.log(unchainedFeature);
-
         try {
             const details = await this.$axios.$patch(
                 constants.urlConstants.updateFeature + feature.id,
                 unchainedFeature
             );
-            commit("updateFeatureSuccess", feature);
+
+            commit("updateFeatureSuccess", {feature: feature, 
+                                            active: unchainedFeature.active, 
+                                            lastToggled: unchainedFeature.lastToggled, 
+                                            toggledBy: unchainedFeature.toggledBy});
         } catch (error) {
+            console.log(error);
             commit("updateFeatureFailure", error.message);
         }
     },
@@ -430,9 +433,20 @@ const mutations = {
         state.updateFeature.loading = true;
         state.updateFeature.error = null;
     },
-    updateFeatureSuccess(state, feature) {
-        feature.active = !feature.active;
-        state.updateFeature.payload = response;
+    updateFeatureSuccess(state, payload) {
+        var index = state.appDetails.payload.featuresById.findIndex(
+            feature => feature.id === payload.feature.id
+        );
+
+        var feature = null;
+        if (index > -1) {
+            feature = state.appDetails.payload.featuresById[index];
+            feature.toggledBy = payload.toggledBy;
+            feature.active = payload.active;
+            feature.lastToggled = payload.lastToggled;
+        }
+
+        state.updateFeature.payload = feature;
         state.updateFeature.loading = false;
         state.updateFeature.error = null;
     },

--- a/store/applications.js
+++ b/store/applications.js
@@ -174,7 +174,6 @@ const actions = {
                                             lastToggled: unchainedFeature.lastToggled, 
                                             toggledBy: unchainedFeature.toggledBy});
         } catch (error) {
-            console.log(error);
             commit("updateFeatureFailure", error.message);
         }
     },


### PR DESCRIPTION
This changes supports setting/getting the date a feature was last toggled and by who. If the sorting PR is approved, some changes will have to be made in updateFeatureSuccess mutation. Added moment for date/time formatting.

This is not part of a GitHub issue.